### PR TITLE
attachment support + cc list check

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -2,6 +2,7 @@ from django.core.mail.backends.base import BaseEmailBackend
 from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMultiAlternatives
 from django.conf import settings
+from email.mime.base import MIMEBase
 import sendgrid
 
 try:
@@ -64,6 +65,11 @@ class SendGridBackend(BaseEmailBackend):
 		if email.cc and not self.fail_silently:
             raise Exception("CC list must be empty for SendGridHttpsBackEnd. CC not supported by the web API")
 
+		for attachment in email.attachments:
+            if isinstance(attachment, MIMEBase):
+                mail.add_attachment_stream(attachment.get_filename(), attachment.get_payload())
+            elif isinstance(attachment, tuple):
+                mail.add_attachment_stream(attachment[0],attachment[1])
 
         if email.extra_headers:
             if "Reply-To" in email.extra_headers:


### PR DESCRIPTION
Added support for attachments
Support added for both types: tuple as well as MIMEBase
as described in
https://docs.djangoproject.com/en/dev/topics/email/#django.core.mail.EmailMessage

Added exception when cc is not empty and fail_silently is disabled
