### PR TITLE
fixed tab expansion on vim; possible syntax error on some boxes

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -65,7 +65,7 @@ class SendGridBackend(BaseEmailBackend):
 		if email.cc and not self.fail_silently:
             raise Exception("CC list must be empty for SendGridHttpsBackEnd. CC not supported by the web API")
 
-		for attachment in email.attachments:
+        for attachment in email.attachments:
             if isinstance(attachment, MIMEBase):
                 mail.add_attachment_stream(attachment.get_filename(), attachment.get_payload())
             elif isinstance(attachment, tuple):


### PR DESCRIPTION
Oops! Some how vim did not expand the tabs correctly. If you do a diff, it might not be visible but there is a change. 

It worked on OS X shell just fine but complained on debian. (by default a tab is expanded to 8 spaces)
Sorry!
