### PR TITLE
Add cc bcc fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     license='MIT',
     description='SendGrid Backend for Django',
     long_description=open('./README.rst').read(),
-    install_requires=["sendgrid==0.5.1"],
+    install_requires=["sendgrid==1.3.0"],
 )

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -59,6 +59,8 @@ class SendGridBackend(BaseEmailBackend):
     def _build_sg_mail(self, email):
         mail = sendgrid.Mail()
         mail.add_to(email.to)
+        mail.add_cc(email.cc)
+        mail.add_bcc(email.bcc)
         mail.set_text(email.body)
         mail.set_subject(email.subject)
         mail.set_from(email.from_email)


### PR DESCRIPTION
Hey and thanks for the project! I need to possibly have cc and bcc fields. Since Django has good defaults and the sengrid library is well written if this doesn't exist it will gracefully not fail.

Also, it looks like cc wasn't completely supported until version 1.1 or so and as such I've bumped the version requirement.