### PR TITLE
Use SendGrid API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build
 dist
 sendgrid_django.egg-info
 .pyc
+.eggs
 venv

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,13 @@ Add the following to your project’s **settings.py**:
 .. code:: python
 
     EMAIL_BACKEND = "sgbackend.SendGridBackend"
+    SENDGRID_API_KEY = "Your SendGrid API Key"
+
+Or, SendGrid username and password can be used instead of an API key:
+
+.. code:: python
+
+    EMAIL_BACKEND = "sgbackend.SendGridBackend"
     SENDGRID_USER = "Your SendGrid Username"
     SENDGRID_PASSWORD = "Your SendGrid Password"
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     license='MIT',
     description='SendGrid Backend for Django',
     long_description=open('./README.rst').read(),
-    install_requires=["sendgrid==1.3.0"],
+    install_requires=["sendgrid==1.4.0"],
 )


### PR DESCRIPTION
Add a Django setting for `SENDGRID_API_KEY` and prefer it over username and password.

Fixes https://github.com/elbuo8/sendgrid-django/issues/9