### PR TITLE
unpin sendgrid version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     license='MIT',
     description='SendGrid Backend for Django',
     long_description=open('./README.rst').read(),
-    install_requires=["sendgrid >= 1.4.0, < 2"],
+    install_requires=["sendgrid >= 1.4.0, < 3"],
 )

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,5 @@ setup(
     license='MIT',
     description='SendGrid Backend for Django',
     long_description=open('./README.rst').read(),
-    install_requires=["sendgrid==1.4.0"],
+    install_requires=["sendgrid >= 1.4.0, < 2"],
 )


### PR DESCRIPTION
Love this simple Django mail backend!  Noticed it's currently pinned at sendgrid v1.4.0, which is quite a number of [features and bugfixes behind](https://github.com/sendgrid/sendgrid-python/blob/master/CHANGELOG.md).  Sendgrid's been good at following semver, so this patch would unpin the upstream version to anything below 2.X.