### PR TITLE
Allow for HTML-only emails when content_subtype is set to html

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -76,6 +76,9 @@ class SendGridBackend(BaseEmailBackend):
             for alt in email.alternatives:
                 if alt[1] == "text/html":
                     mail.set_html(alt[0])
+        elif email.content_subtype == "html":
+            mail.set_html(email.body)
+            mail.set_text("")
 
         for attachment in email.attachments:
             if isinstance(attachment, MIMEBase):


### PR DESCRIPTION
This adds support for html-only emails. I've applied a commit by rsniezynski that basically does what I was going to do :) He never sent a PR though, so here I am.