### PR TITLE
Add SendGrid Template substitutions to SMTP API Header

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -105,6 +105,9 @@ class SendGridBackend(BaseEmailBackend):
             if "Filters" in email.extra_headers:
                 mail.smtpapi.data['filters'] = email.extra_headers["Filters"]
 
+            if "sub" in email.extra_headers:
+                mail.smtpapi.data['sub'] = email.extra_headers["sub"]
+
             for attachment in email.attachments:
                 mail.add_attachment_stream(attachment[0], attachment[1])
 


### PR DESCRIPTION
As per https://sendgrid.com/docs/API_Reference/Web_API_v3/Transactional_Templates/smtpapi.html, the SMTP API allows the use of template substitutions.

Example usage:
```
    from django.core.mail import EmailMultiAlternatives
    subject = "My cool subject"
    from_email = "sender@email.com"
    to_email = "receiver@email.com"

    mail = EmailMultiAlternatives(
        subject=subject,
        from_email=from_email,
        to=[to_email],
        body="",
        headers={
            "Reply-To": from_email,
            "sub": {
                ":sendername": [  # ':sendername' is a custom template replacement defined in SendGrid
                    "John Doe"  # Number of array entries == number of recipients in the EmailMultiAlternatives 'to' param
                ],
            },
            "Filters": {
                "templates": {
                    "settings": {
                        "enable": 1,
                        "template_id": "xxxxxxxx-yyyy-xxxx-yyyy-xxxxxxxxxxxx"
                    }
                }
            }
        }
    )
    mail.attach_alternative("some text that will get replaced anyway", "text/html")
    mail.send()
```