### PR TITLE
Python 2 compatibility fix

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -1,7 +1,11 @@
 import base64
 import sys
-import urllib
 from email.mime.base import MIMEBase
+
+try:
+    from urllib.error import HTTPError
+except ImportError:
+    from urllib2 import HTTPError
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -55,7 +59,7 @@ class SendGridBackend(BaseEmailBackend):
             try:
                 self.sg.client.mail.send.post(request_body=mail)
                 count += 1
-            except urllib.error.HTTPError as e:
+            except HTTPError as e:
                 if not self.fail_silently:
                     raise
         return count

--- a/sgbackend/version.py
+++ b/sgbackend/version.py
@@ -1,2 +1,2 @@
-version_info = (4, 0, 0)
+version_info = (4, 0, 1)
 __version__ = '.'.join(str(v) for v in version_info)


### PR DESCRIPTION
`urllib` is only available on Python 3. Added fallback for older versions with `urllib2`.

Error handling in client documentation: 
https://github.com/sendgrid/sendgrid-python/blob/master/TROUBLESHOOTING.md#error-messages