### PR TITLE
Allow API key to be passed in constructor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,5 +92,8 @@ Development
 Install dependencies::
     `pip install -r requirements-dev.txt`
 
-Run the tests with coverage
+Run the tests with coverage::
     `pytest --cov=sgbackend`
+
+If you see the error "No module named sgbackend", run::
+    `pip install -e .`

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,17 @@ Example
 
     mail.send()
 
+To create an instance of a SendGridBackend with an API key other than that provided in settings, pass `api_key` to the constructor
+
+.. code::python
+
+    from sgbackend import SendGridBackend
+    from django.core.mail import send_mail
+
+    connection = SendGridBackend(api_key='your key')
+
+    send_mail(<subject etc>, connection=connection)
+
 
 License
 -------
@@ -73,3 +84,13 @@ MIT
 
 
 Enjoy :)
+
+
+Development
+-----------
+
+Install dependencies::
+    `pip install -r requirements-dev.txt`
+
+Run the tests with coverage
+    `pytest --cov=sgbackend`

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 coverage
 pytest
 pytest-cov
+pytest-django
+Django
+sendgrid>=3.6.5,<4

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -38,7 +38,10 @@ class SendGridBackend(BaseEmailBackend):
     def __init__(self, fail_silently=False, **kwargs):
         super(SendGridBackend, self).__init__(
             fail_silently=fail_silently, **kwargs)
-        self.api_key = getattr(settings, "SENDGRID_API_KEY", None)
+        if 'api_key' in kwargs:
+            self.api_key = kwargs['api_key']
+        else:
+            self.api_key = getattr(settings, "SENDGRID_API_KEY", None)
 
         if not self.api_key:
             raise ImproperlyConfigured('''

--- a/tests/test_api_key.py
+++ b/tests/test_api_key.py
@@ -1,0 +1,21 @@
+from sgbackend import SendGridBackend
+
+
+def test_read_from_settings_by_default(settings):
+    """API key should be read from settings if not provided in init."""
+    settings.SENDGRID_API_KEY = 'somerandom key'
+    sg = SendGridBackend()
+
+    assert sg.api_key == settings.SENDGRID_API_KEY
+
+
+def test_read_from_init_if_provided(settings):
+    """Should pick up API key from init, if provided."""
+    settings.SENDGRID_API_KEY = 'somerandom key'
+    actual_key = 'another'
+
+    sg = SendGridBackend(api_key=actual_key)
+
+    assert sg.api_key == actual_key
+
+""" Note: no API key configuration is tested in test_mail."""


### PR DESCRIPTION
Closes #54 

- Added some dev dependencies that are needed to run tests
- Tests written for this feature
- Added `pytest-django` which has some convenient fixtures