### PR TITLE
Revert to standard urllib error handling.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage
-pytest
+pytest>=3.6
 pytest-cov
 pytest-django
 Django

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ setup(
     license='MIT',
     description='SendGrid Backend for Django',
     long_description=open('./README.rst').read(),
-    install_requires=["sendgrid >= 3.5, < 4"],
+    install_requires=[
+        "python_http_client >= 2.1.*, <2.3",
+        "sendgrid >= 3.5, <4",
+    ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -3,7 +3,11 @@ from .version import __version__
 import base64
 import sys
 from email.mime.base import MIMEBase
-from python_http_client.exceptions import HTTPError
+
+try:
+    from urllib.error import HTTPError  # pragma: no cover
+except ImportError: # pragma: no cover
+    from urllib2 import HTTPError  # pragma: no cover
 
 try:
     import rfc822

--- a/tests/test_mail.py
+++ b/tests/test_mail.py
@@ -3,32 +3,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.mail import EmailMessage
 from django.core.mail import EmailMultiAlternatives
 from django.test import SimpleTestCase as TestCase
-from python_http_client.client import HTTPError
-from python_http_client.client import Client, Response
-from python_http_client.exceptions import handle_error
 
 from sgbackend import SendGridBackend
 
 settings.configure()
-
-
-class MockException(HTTPError):
-    def __init__(self, code):
-        self.code = code
-        self.reason = 'REASON'
-        self.hdrs = 'HEADERS'
-
-    def read(self):
-        return 'BODY'
-
-
-class MockClient(Client):
-    def __init__(self, host):
-        self.response_code = 400
-        Client.__init__(self, host)
-
-    def _make_request(self, opener, request):
-        raise handle_error(MockException(self.response_code))
 
 
 class SendGridBackendTests(TestCase):
@@ -220,11 +198,3 @@ class SendGridBackendTests(TestCase):
                  'personalizations': [{'subject': ''}],
                  'subject': ''}
             )
-            
-    def test_send_messages_error(self):
-        mock_client = MockClient(self.host)
-        backend = SendGridBackend()
-        backend.sg.client = mock_client
-        msg = EmailMessage()
-        with self.assertRaises(HTTPError):
-            backend.send_messages(emails=[SendGridBackend()._build_sg_mail(msg)])


### PR DESCRIPTION
This reverts commit e4dfae40860f4fdc224c4c8065d77c45f9c36bb8, which tries to fix #74 by importing HTTPError from `python_http_client`. This change isn't necessary, since the error in #74 was being caused by a bug in `sendgrid-python` which resulted in the wrong version of `python_http_client` being installed: https://github.com/sendgrid/sendgrid-python/issues/321

Since the bug is fixed in `sendgrid-python` 4.2.1, but this library still uses `sendgrid-python` 3.5+, I've added additional installation constraints on `python_http_client` so that it should never install a version with custom error handling (2.3.0 or above). This constraint should be removed when we upgrade to `sendgrid-python` 4.