### PR TITLE
Fix: Error sending attachments with MimeType text/*

### DIFF
--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -144,7 +144,12 @@ class SendGridBackend(BaseEmailBackend):
             elif isinstance(attachment, tuple):
                 attach = Attachment()
                 attach.set_filename(attachment[0])
-                base64_attachment = base64.b64encode(attachment[1])
+                # encoding the StringIO(Text mimetype) object. If attachment is BytesIO object, we don't need to encode
+                if type(attachment[1]) == str:
+                    attachment_object = attachment[1].encode()
+                else:
+                    attachment_object = attachment[1]
+                base64_attachment = base64.b64encode(attachment_object)
                 if sys.version_info >= (3,):
                     attach.set_content(str(base64_attachment, 'utf-8'))
                 else:

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -144,7 +144,8 @@ class SendGridBackend(BaseEmailBackend):
             elif isinstance(attachment, tuple):
                 attach = Attachment()
                 attach.set_filename(attachment[0])
-                # encoding the StringIO(Text mimetype) object. If attachment is BytesIO object, we don't need to encode
+                # Encoding is required only for Python 3.6.
+                # Encoding the StringIO(Text Mimetype) object. BytesIO object will raise an exception for Python 3.6
                 try:
                     attachment_object = attachment[1].encode()
                 except:

--- a/sgbackend/mail.py
+++ b/sgbackend/mail.py
@@ -145,9 +145,9 @@ class SendGridBackend(BaseEmailBackend):
                 attach = Attachment()
                 attach.set_filename(attachment[0])
                 # encoding the StringIO(Text mimetype) object. If attachment is BytesIO object, we don't need to encode
-                if type(attachment[1]) == str:
+                try:
                     attachment_object = attachment[1].encode()
-                else:
+                except:
                     attachment_object = attachment[1]
                 base64_attachment = base64.b64encode(attachment_object)
                 if sys.version_info >= (3,):


### PR DESCRIPTION
- Encode the attachment if it is a StringIO object i.e text/* MimeType


Issue Resolved : [Error sending attachments with MimeType text/* #61](https://github.com/elbuo8/sendgrid-django/issues/61)